### PR TITLE
added support for specifying mongodb host and port

### DIFF
--- a/config/app.json.sample
+++ b/config/app.json.sample
@@ -4,6 +4,9 @@
   "tracking_port" : 8000,
   "dashboard_port" : 8080,
 
+  "mongo_host" : "localhost",
+  "mongo_port" : 27017,
+
   "enable_dashboard" : true,
 
   "capistrano" : {

--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ try {
 }
 var config = JSON.parse(configJSON.toString());
 
-db = new mongo.Db('hummingbird', new mongo.Server('localhost', 27017, {}), {});
+db = new mongo.Db('hummingbird', new mongo.Server(config.mongo_host, config.mongo_port, {}), {});
 
 db.addListener("error", function(error) {
   console.log("Error connecting to mongo -- perhaps it isn't running?");


### PR DESCRIPTION
Hi Michael,

I was interested in hummingbird so I downloaded it and while setting it up noted that I couldn't specify a mongodb host or port without changing the source for the server.js file.

I've patched the server.js file and app.json.sample as needed to support such functionality and was wondering if you would be interested in pulling this into master.

Thanks,
Tim
