### PR TITLE
Enables hummingbird to be used behind a proxy server (nginx, for example)

### DIFF
--- a/lib/hummingbird.js
+++ b/lib/hummingbird.js
@@ -57,7 +57,7 @@ Hummingbird.prototype = {
     env.timestamp = new Date();
     // sys.log(JSON.stringify(env, null, 2));
 
-    env.ip = req.connection.remoteAddress;
+    env.ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
     var view = new View(env);
 
     env.url_key = view.urlKey;


### PR DESCRIPTION
I have installed hummingbird behing a nginx server. By default, humingbird looks for the connection remote IP. With a local nginx server in front of the nodejs server this IP is always 127.0.0.1. This path just looks for the header x-forwarded-for in the request and uses it as remote ip. If this header doesn't exist it uses the req.connection.ip as usual.
