### PR TITLE
Fix the npm install issue

### DIFF
--- a/lib/metrics/locations.js
+++ b/lib/metrics/locations.js
@@ -3,7 +3,7 @@
 // Sends individual requests, geolocated using ip address
 
 var util   = require('util');
-var geoip  = require('geoip-no-city-leak');
+var geoip  = require('geoip');
 var path   = require('path');
 var Metric = require('../metric');
 var http   = require('http');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "socket.io": "0.9.6",
     "node-static": "0.5.9",
-    "geoip-no-city-leak": "0.4.9-1"
+    "geoip": "0.4.10"
   },
   "domains": [
     "demo.hummingbirdstats.com"


### PR DESCRIPTION
If the you have encounter the problem when installing it. You can consider pull this commit

<pre>
npm install </pre>

<pre>
npm WARN package.json node-static@0.5.9 No repository field.
npm http GET https://registry.npmjs.org/geoip-no-city-leak/0.4.9-1
npm http GET https://registry.npmjs.org/socket.io/0.9.6
npm http 304 https://registry.npmjs.org/geoip-no-city-leak/0.4.9-1
npm http 304 https://registry.npmjs.org/socket.io/0.9.6

> geoip-no-city-leak@0.4.9-1 install /Users/zzn/ws/siyuan/hummingbird/node_modules/geoip-no-city-leak
> node-gyp rebuild

npm http GET https://registry.npmjs.org/redis/0.6.7
npm http GET https://registry.npmjs.org/policyfile/0.0.4
npm http GET https://registry.npmjs.org/socket.io-client/0.9.6
npm http 304 https://registry.npmjs.org/redis/0.6.7
npm http 304 https://registry.npmjs.org/policyfile/0.0.4
npm WARN package.json policyfile@0.0.4 No repository field.
npm WARN package.json policyfile@0.0.4 'repositories' (plural) Not supported.
npm WARN package.json Please pick one as the 'repository' field
  CXX(target) Release/obj.target/geoip/src/city.o
npm http 304 https://registry.npmjs.org/socket.io-client/0.9.6
npm http GET https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.6.tgz
In file included from ../src/city.cc:7:
../src/city.h:12:10: fatal error: 'GeoIPCity.h' file not found
#include <GeoIPCity.h>
         ^
1 error generated.
make: *** [Release/obj.target/geoip/src/city.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/Cellar/node/0.10.12/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:267:23)
gyp ERR! stack     at ChildProcess.EventEmitter.emit (events.js:98:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:789:12)
gyp ERR! System Darwin 12.4.0
gyp ERR! command "node" "/usr/local/Cellar/node/0.10.12/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/zzn/ws/siyuan/hummingbird/node_modules/geoip-no-city-leak
gyp ERR! node -v v0.10.12
gyp ERR! node-gyp -v v0.10.0
gyp ERR! not ok
npm ERR! weird error 1
npm http 200 https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.6.tgz
npm ERR! not ok code 0
13:36:45 zzn@zzn-macbookpro ⮁ ~ ⮁ ws ⮁ siyuan ⮁ hummingbird ⮀ master ⮀ $ ⮀npm install geoip-no-city-leak
npm WARN package.json node-static@0.5.9 No repository field.
npm http GET https://registry.npmjs.org/geoip-no-city-leak/0.4.9-1
npm http 304 https://registry.npmjs.org/geoip-no-city-leak/0.4.9-1

> geoip-no-city-leak@0.4.9-1 install /Users/zzn/ws/siyuan/hummingbird/node_modules/geoip-no-city-leak
> node-gyp rebuild

  CXX(target) Release/obj.target/geoip/src/city.o
In file included from ../src/city.cc:7:
../src/city.h:12:10: fatal error: 'GeoIPCity.h' file not found
#include <GeoIPCity.h>
         ^
1 error generated.
make: *** [Release/obj.target/geoip/src/city.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/Cellar/node/0.10.12/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:267:23)
gyp ERR! stack     at ChildProcess.EventEmitter.emit (events.js:98:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:789:12)
gyp ERR! System Darwin 12.4.0
gyp ERR! command "node" "/usr/local/Cellar/node/0.10.12/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/zzn/ws/siyuan/hummingbird/node_modules/geoip-no-city-leak
gyp ERR! node -v v0.10.12
gyp ERR! node-gyp -v v0.10.0
gyp ERR! not ok
npm ERR! weird error 1
npm ERR! not ok code 0
</pre>
